### PR TITLE
Fixed indentation error.

### DIFF
--- a/qtodotxt/app.py
+++ b/qtodotxt/app.py
@@ -31,7 +31,7 @@ class TrayIcon(QtGui.QSystemTrayIcon):
         view = self._controller.getView()
         icon = getIcon('qtodotxt.ico')
         QtGui.QSystemTrayIcon.__init__(self, icon, view)
-	self.activated.connect(self._onActivated)
+        self.activated.connect(self._onActivated)
         self.setToolTip('QTodoTxt')
     
     def _onActivated(self):


### PR DESCRIPTION
Hi, Mathieu! I like QTodoTxt a lot. I discovered that one line in app.py starts with a tab; my change replaces the tab with spaces to match all other lines. It might also be worth thinking about the reason I discovered this: the main executable starts with

```
#!/usr/bin/env python
```

On my system (Arch Linux), this invokes python3, and in python3 the inconsistent indentation is an error. And I see that the app won't work with python3, so for myself I need to change the header to

```
#!/usr/bin/env python2
```

I didn't commit that change because I'm not sure that is the right thing to do for all users. But it might be a good thing to consider.

Thanks!
