### PR TITLE
Adds support for (un)hiding "future tasks"

### DIFF
--- a/qtodotxt/lib/settings.py
+++ b/qtodotxt/lib/settings.py
@@ -37,7 +37,13 @@ class Settings(object):
     
     def setAutoArchive(self,autoArchive):
         self._setData('auto_archive',autoArchive)
-        
+
+    def getHideFutureTasks(self):
+        return self._getData('hide_future_tasks')
+
+    def setHideFutureTasks(self,hideFutureTasks):
+        self._setData('hide_future_tasks',hideFutureTasks)
+
     def _getData(self, key):
         if self._data:
             return self._data.get(key)

--- a/qtodotxt/lib/task_htmlizer.py
+++ b/qtodotxt/lib/task_htmlizer.py
@@ -26,7 +26,9 @@ class TaskHtmlizer(object):
             text = text.replace('(%s)' % task.priority, self._htmlizePriority(task.priority))
         if task.due is not None:
             text = text.replace('due:%s' % task.due, self._htmlizeDueDate(task.due))
-        
+        if task.threshold is not None:
+            text = text.replace('t:%s' % task.threshold, self._htmlizeThresholdDate(task.threshold))
+
         return self._htmlizeURL(text)
     
     def _htmlizeContext(self, context):
@@ -51,7 +53,16 @@ class TaskHtmlizer(object):
             return '<b><font color="orange">due:%s</font></b>' % dueDateString
         else:
             return '<b><font style="color:red">due:%s</font></b>' % dueDateString
-		
+
+    def _htmlizeThresholdDate(self,thresholdDateString):
+        threshold_date = datetime.strptime(thresholdDateString, '%Y-%m-%d').date()
+        date_now = date.today()
+        tdelta = threshold_date - date_now
+        if tdelta.days > 0:
+            return '<i><font style="color:grey">t:%s</font></i>' % thresholdDateString
+        else:
+            return '<font style="color:orange">t:%s</font>' % thresholdDateString
+
     def _htmlizeURL(self,text):
         regex = re.compile(
             r'((?:http|ftp)s?://' # http:// or https://

--- a/qtodotxt/lib/todolib.py
+++ b/qtodotxt/lib/todolib.py
@@ -2,6 +2,7 @@ import re
 import os
 import codecs
 from argparse import ArgumentError
+from datetime import datetime,date
 
 USE_LAST_FILENAME = 1
 
@@ -128,9 +129,11 @@ class Task(object):
         self.projects = []
         self.priority = None
         self.is_complete = False
+        self.is_future = False
         self._text = ''
         self.due = None
-    
+        self.threshold = None
+
     def parseLine(self, line):
         words = line.split(' ')
         i = 0
@@ -153,6 +156,9 @@ class Task(object):
                 self.projects.append(word[1:])
             elif word.startswith('due:'):
                 self.due = word[4:]
+            elif word.startswith('t:'):
+                self.threshold = word[2:]
+                self.is_future = datetime.strptime(self.threshold, '%Y-%m-%d').date() > date.today()
 
     def _getText(self):
         return self._text

--- a/qtodotxt/ui/controllers/menu_controller.py
+++ b/qtodotxt/ui/controllers/menu_controller.py
@@ -27,6 +27,7 @@ class MenuController(QtCore.QObject):
         preferenceMenu.addAction(self._createPreferenceAction())
         preferenceMenu.addAction(self._autoSavePreferenceAction())
         preferenceMenu.addAction(self._autoArchivePreferenceAction())
+        preferenceMenu.addAction(self._hideFutureTasksAction())
         fileMenu.addSeparator()
         fileMenu.addAction(self._createExitAction())
      
@@ -92,7 +93,13 @@ class MenuController(QtCore.QObject):
         action.triggered.connect(self._main_controller.toggleAutoArchive)
         self.autoArchiveAction = action
         return action
-        
+
+    def _hideFutureTasksAction(self):
+        action = QtGui.QAction('Hide future tasks', self,checkable=True)
+        action.triggered.connect(self._main_controller.toggleHideFutureTasks)
+        self.hideFutureTasksAction = action
+        return action
+
     def changeAutoSaveState(self, value=False):
         self.autoSaveAction.setChecked(value)
         
@@ -101,6 +108,9 @@ class MenuController(QtCore.QObject):
         
     def changeAutoArchiveState(self, value=False):
         self.autoArchiveAction.setChecked(value)
+
+    def changeHideFutureTasksState(self, value=False):
+        self.hideFutureTasksAction.setChecked(value)
 
     def _createExitAction(self):
         action = QtGui.QAction(getIcon('door_in.png'), 'E&xit', self)


### PR DESCRIPTION
When parsing tasks, look for the `t` (aka threshold) tag. If the
threshold date is in the future, then the task is a _future task_. A new
preference controls the global (un)hiding of such tasks.

This adds support for todo.txt's [futureTasks](https://github.com/ginatrapani/todo.txt-cli/wiki/Todo.sh-Add-on-Directory#wiki-futuretasks) filter, which is part of the official add-ons.
