### PR TITLE
Don't crash when parsing invalid dates, and mark invalid dates as such.

### DIFF
--- a/qtodotxt/lib/task_htmlizer.py
+++ b/qtodotxt/lib/task_htmlizer.py
@@ -55,7 +55,10 @@ class TaskHtmlizer(object):
         return '<tt>&nbsp;%s&nbsp;</tt>' % priority
 
     def _htmlizeDueDate(self, dueDateString):
-        due_date = datetime.strptime(dueDateString, '%Y-%m-%d').date()
+        try:
+            due_date = datetime.strptime(dueDateString, '%Y-%m-%d').date()
+        except ValueError:
+            return '<b><font style="color:red">*** Invalid date format! due:%s ***</font></b>' % dueDateString
         date_now = date.today()
         tdelta = due_date - date_now
         if tdelta.days > 7:
@@ -66,7 +69,10 @@ class TaskHtmlizer(object):
             return '<b><font style="color:red">due:%s</font></b>' % dueDateString
 
     def _htmlizeThresholdDate(self,thresholdDateString):
-        threshold_date = datetime.strptime(thresholdDateString, '%Y-%m-%d').date()
+        try:
+            threshold_date = datetime.strptime(thresholdDateString, '%Y-%m-%d').date()
+        except ValueError:
+            return '<b><font style="color:red">*** Invalid date format! t:%s ***</font></b>' % thresholdDateString
         date_now = date.today()
         tdelta = threshold_date - date_now
         if tdelta.days > 0:

--- a/qtodotxt/lib/todolib.py
+++ b/qtodotxt/lib/todolib.py
@@ -183,7 +183,10 @@ class Task(object):
                 self.due = word[4:]
             elif word.startswith('t:'):
                 self.threshold = word[2:]
-                self.is_future = datetime.strptime(self.threshold, '%Y-%m-%d').date() > date.today()
+                try:
+                    self.is_future = datetime.strptime(self.threshold, '%Y-%m-%d').date() > date.today()
+                except ValueError:
+                    self.is_future = False
 
     def _getText(self):
         return self._text


### PR DESCRIPTION
This is a quick fix to avoid the crash reported on issue #38.
- On `todolib.py`, avoid crashing if the threshold date is invalid;
- On `task_htmlizer.py`, avoid crashing if the due and/or threshold date is invalid, and add a "**\* Invalid date format! ***" message so the user know there's something wrong;

I know the ideal solution maybe would involve displaying a proper error dialog, but I couldn't find an easy way to do that from the task list controller.

This was a 10 minute hack, so please feel free to discard it if you decide to implement a more elegant / robust solution.
