### PR TITLE
bin/qtodotxt: Use Python2 explicitly

### DIFF
--- a/bin/qtodotxt
+++ b/bin/qtodotxt
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import os


### PR DESCRIPTION
Uses /usr/bin/env python2 instead of /usr/bin/env python.

This will achieve greater portability.
