### PR TITLE
"." is a proper character in a URL

### DIFF
--- a/qtodotxt/lib/task_htmlizer.py
+++ b/qtodotxt/lib/task_htmlizer.py
@@ -87,7 +87,7 @@ class TaskHtmlizer(object):
             r'localhost|'  # localhost...
             r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'  # ...or ip
             r'(?::\d+)?'  # optional port
-            r'(?:[-_/?a-zA-Z0-9\.]*))', re.IGNORECASE)
+            r'(?:[^ ,]*))', re.IGNORECASE) # URL ends with either a space or a comma
         return regex.sub(r'<a href="\1">\1</a>', text)
 
     def _htmlizeCreatedCompleted(self, text, raw_text):


### PR DESCRIPTION
URL's like http://domain.tld/file.html were not properly processed (the link ended up being http://domain.tld/file). Actually, isn't this still too narrow?
