### PR TITLE
Update Debian/Ubuntu download section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ Feel free to try !</p>
 </li>
 </ul><p>For Debian/Ubuntu you can also add the following repo to your sources.list:</p>
 
-<pre><code>sudo echo "deb http://dl.bintray.com/mnantern/deb /" &gt;&gt; /etc/apt/sources.list.d/qtodotxt.list
+<pre><code>echo "deb http://dl.bintray.com/mnantern/deb /" | sudo tee /etc/apt/sources.list.d/qtodotxt.list
 </code></pre>
 
 <h2>


### PR DESCRIPTION
Previously, only `echo` was elevated to run as superuser, while the shell (which handled the output redirection and thus writing the sources list) ran as a normal user. This causes a problem since the sources.list.d directory is not writeable by most users.

The new version pipes the output to `tee`, which is elevated to run as root, so there is no permissions conflict.
