### PR TITLE
Update autocomplete_lineedit.py

### DIFF
--- a/qtodotxt/ui/controls/autocomplete_lineedit.py
+++ b/qtodotxt/ui/controls/autocomplete_lineedit.py
@@ -33,7 +33,7 @@ class AutoCompleteEdit(QtGui.QLineEdit):
 
         newtext = currentText[:textFirstPart] + completion + " " + currentText[textLastPart:]
         newCursorPos = self.cursorPosition() + (len(completion) - completionPrefixSize) + 1
-        
+
         self.setText(newtext)
         self.setCursorPosition(newCursorPos)
 


### PR DESCRIPTION
Avoid "qtodotxt/ui/controls/autocomplete_lineedit.py:36:1: W293 blank line contains whitespace"