### PR TITLE
Change priority handling

### DIFF
--- a/qtodotxt/lib/task_parser.py
+++ b/qtodotxt/lib/task_parser.py
@@ -65,8 +65,9 @@ class Task(object):
             self.priority = LOWEST_PRIORITY
             self.text = '(%s) %s' % (self.priority, self.text)
         elif self.priority == HIGHEST_PRIORITY:
-            self.priority = None
-            self.text = self.text[4:]
+            # do nothing
+            self.priority = self.priority
+            self.text = self.text
         else:
             oldPriority = self.priority
             self.priority = chr(ord(self.priority) - 1)
@@ -74,8 +75,9 @@ class Task(object):
 
     def decreasePriority(self):
         if self.priority is None:
-            self.priority = HIGHEST_PRIORITY
-            self.text = '(%s) %s' % (self.priority, self.text)
+            # do nothing
+            self.priority = self.priority
+            self.text = self.text
         elif self.priority == LOWEST_PRIORITY:
             self.priority = None
             self.text = self.text[4:]

--- a/qtodotxt/lib/task_parser.py
+++ b/qtodotxt/lib/task_parser.py
@@ -2,8 +2,8 @@ import re
 from datetime import datetime, date
 
 
-HIGHER_PRIORITY = 'A'
-LOWER_PRIORITY = 'Z'
+HIGHEST_PRIORITY = 'A'
+LOWEST_PRIORITY = 'Z'
 
 
 class Task(object):
@@ -62,9 +62,9 @@ class Task(object):
 
     def increasePriority(self):
         if self.priority is None:
-            self.priority = LOWER_PRIORITY
-            self.text = '(%s) %s' % (LOWER_PRIORITY, self.text)
-        elif self.priority == HIGHER_PRIORITY:
+            self.priority = LOWEST_PRIORITY
+            self.text = '(%s) %s' % (LOWEST_PRIORITY, self.text)
+        elif self.priority == HIGHEST_PRIORITY:
             self.priority = None
             self.text = self.text[4:]
         else:
@@ -74,9 +74,9 @@ class Task(object):
 
     def decreasePriority(self):
         if self.priority is None:
-            self.priority = HIGHER_PRIORITY
-            self.text = '(%s) %s' % (HIGHER_PRIORITY, self.text)
-        elif self.priority == LOWER_PRIORITY:
+            self.priority = HIGHEST_PRIORITY
+            self.text = '(%s) %s' % (HIGHEST_PRIORITY, self.text)
+        elif self.priority == LOWEST_PRIORITY:
             self.text = self.text[4:]
             self.priority = None
         else:

--- a/qtodotxt/lib/task_parser.py
+++ b/qtodotxt/lib/task_parser.py
@@ -61,30 +61,24 @@ class Task(object):
             self.parseLine(line)
 
     def increasePriority(self):
-        if self.priority is None:
-            self.priority = LOWEST_PRIORITY
-            self.text = '(%s) %s' % (self.priority, self.text)
-        elif self.priority == HIGHEST_PRIORITY:
-            # do nothing
-            self.priority = self.priority
-            self.text = self.text
-        else:
-            oldPriority = self.priority
-            self.priority = chr(ord(self.priority) - 1)
-            self.text = re.sub('^\(%s\) ' % oldPriority, '(%s) ' % self.priority, self.text)
+        if self.priority != HIGHEST_PRIORITY:
+            if self.priority is None:
+                self.priority = LOWEST_PRIORITY
+                self.text = '(%s) %s' % (self.priority, self.text)
+            else:
+                oldPriority = self.priority
+                self.priority = chr(ord(self.priority) - 1)
+                self.text = re.sub('^\(%s\) ' % oldPriority, '(%s) ' % self.priority, self.text)
 
     def decreasePriority(self):
-        if self.priority is None:
-            # do nothing
-            self.priority = self.priority
-            self.text = self.text
-        elif self.priority == LOWEST_PRIORITY:
-            self.priority = None
-            self.text = self.text[4:]
-        else:
-            oldPriority = self.priority
-            self.priority = chr(ord(self.priority) + 1)
-            self.text = re.sub('^\(%s\) ' % oldPriority, '(%s) ' % self.priority, self.text)
+        if self.priority != None:
+            if self.priority == LOWEST_PRIORITY:
+                self.priority = None
+                self.text = self.text[4:]
+            else:
+                oldPriority = self.priority
+                self.priority = chr(ord(self.priority) + 1)
+                self.text = re.sub('^\(%s\) ' % oldPriority, '(%s) ' % self.priority, self.text)
     text = property(_getText, _setText)
 
 

--- a/qtodotxt/lib/task_parser.py
+++ b/qtodotxt/lib/task_parser.py
@@ -63,26 +63,26 @@ class Task(object):
     def increasePriority(self):
         if self.priority is None:
             self.priority = LOWEST_PRIORITY
-            self.text = '(%s) %s' % (LOWEST_PRIORITY, self.text)
+            self.text = '(%s) %s' % (self.priority, self.text)
         elif self.priority == HIGHEST_PRIORITY:
             self.priority = None
             self.text = self.text[4:]
         else:
-            newPriority = chr(ord(self.priority) - 1)
-            self.text = re.sub('^\(%s\) ' % self.priority, '(%s) ' % newPriority, self.text)
-            self.priority = newPriority
+            oldPriority = self.priority
+            self.priority = chr(ord(self.priority) - 1)
+            self.text = re.sub('^\(%s\) ' % oldPriority, '(%s) ' % self.priority, self.text)
 
     def decreasePriority(self):
         if self.priority is None:
             self.priority = HIGHEST_PRIORITY
-            self.text = '(%s) %s' % (HIGHEST_PRIORITY, self.text)
+            self.text = '(%s) %s' % (self.priority, self.text)
         elif self.priority == LOWEST_PRIORITY:
-            self.text = self.text[4:]
             self.priority = None
+            self.text = self.text[4:]
         else:
-            newPriority = chr(ord(self.priority) + 1)
-            self.text = re.sub('^\(%s\) ' % self.priority, '(%s) ' % newPriority, self.text)
-            self.priority = newPriority
+            oldPriority = self.priority
+            self.priority = chr(ord(self.priority) + 1)
+            self.text = re.sub('^\(%s\) ' % oldPriority, '(%s) ' % self.priority, self.text)
     text = property(_getText, _setText)
 
 

--- a/qtodotxt/lib/task_parser.py
+++ b/qtodotxt/lib/task_parser.py
@@ -1,5 +1,8 @@
 import re
+import string
 from datetime import datetime, date
+
+from PySide import QtCore
 
 
 HIGHEST_PRIORITY = 'A'
@@ -10,7 +13,20 @@ class Task(object):
 
     def __init__(self, line):
         self.reset()
-        self._user_lowest_priority = 'D'
+
+        # read and validate user_lowest_priority
+        # TODO: make user_lowest_priority changeable from gui
+        default_lowest_priority = "D"
+        settings = QtCore.QSettings()
+        user_lowest_priority = settings.value("user_lowest_priority", default_lowest_priority)
+        if str(user_lowest_priority).isupper():
+            self._user_lowest_priority = user_lowest_priority
+        else:
+            self._user_lowest_priority = default_lowest_priority
+            # make sure other parts of the application using this value
+            # always get a valid value
+            settings.setValue("user_lowest_priority", self._user_lowest_priority)
+
         if line:
             self.parseLine(line)
 

--- a/qtodotxt/lib/task_parser.py
+++ b/qtodotxt/lib/task_parser.py
@@ -10,6 +10,7 @@ class Task(object):
 
     def __init__(self, line):
         self.reset()
+        self._user_lowest_priority = 'D'
         if line:
             self.parseLine(line)
 
@@ -62,8 +63,8 @@ class Task(object):
 
     def increasePriority(self):
         if self.priority != HIGHEST_PRIORITY:
-            if self.priority is None:
-                self.priority = LOWEST_PRIORITY
+            if (self.priority == None):
+                self.priority = self._user_lowest_priority
                 self.text = '(%s) %s' % (self.priority, self.text)
             else:
                 oldPriority = self.priority
@@ -72,7 +73,7 @@ class Task(object):
 
     def decreasePriority(self):
         if self.priority != None:
-            if self.priority == LOWEST_PRIORITY:
+            if (self.priority == self._user_lowest_priority) or (self.priority == LOWEST_PRIORITY):
                 self.priority = None
                 self.text = self.text[4:]
             else:


### PR DESCRIPTION
This pull request will introduce two changes:
1. Stop cycling priorities. 
2. Add possibility for a user defined lower priority.

**ad 1:** 
Currently, "increasing" the priority of a priority-(A) task will gave you a task with no priority, and further increasing the priority of this task will give you a priority-(Z) task. Obviously, priority (Z) is NOT higher than priority (A), so I consider this behaviour quite confusing. With the proposed changes, trying to increase the priority of a priority-(A) task will still lead to a priority-(A) task. This makes sense (imho), because priority (A) is the highest priority by definition.

The analogous behaviour is implemented when trying to decrease the priority of tasks with no priority. Here "no priority" is considered as the lowest possible priority of a task.

**ad 2:**
If you use only a few priorities, say A-D, the remaining priorities E-Z are quite annoying, especially when trying to change the priority from one of really used priorities to "no priority" and vice versa, and using the "increase / decrease priority" commands. This is true with the current implementation, but gets even worse with the proposed changes 1.

Therefore I implemented the possibility for setting a user defined lower priority. Up to now, this is only possible by manual editing the .cfg file (add to your .cfg file for example: `"user_lowest_priority": "D"`), but I'm planning to make this changeable from the GUI too.
