### PR TITLE
Switch position of some task related actions

### DIFF
--- a/qtodotxt/ui/controllers/main_controller.py
+++ b/qtodotxt/ui/controllers/main_controller.py
@@ -76,11 +76,11 @@ class MainController(QtCore.QObject):
         toolbar.addAction(self._tasks_list_controller.createTaskAction)
         toolbar.addAction(self._tasks_list_controller.editTaskAction)
         toolbar.addSeparator()
-        toolbar.addAction(self._tasks_list_controller.deleteSelectedTasksAction)
         toolbar.addAction(self._tasks_list_controller.completeSelectedTasksAction)
+        toolbar.addAction(self._tasks_list_controller.deleteSelectedTasksAction)
         toolbar.addSeparator()
-        toolbar.addAction(self._tasks_list_controller.decreasePrioritySelectedTasksAction)
         toolbar.addAction(self._tasks_list_controller.increasePrioritySelectedTasksAction)
+        toolbar.addAction(self._tasks_list_controller.decreasePrioritySelectedTasksAction)
         toolbar.visibilityChanged.connect(self._toolbar_visibility_changed)
         if not self._show_toolbar:
             toolbar.hide()
@@ -170,11 +170,11 @@ class MainController(QtCore.QObject):
         self._contextMenu = QtGui.QMenu()
         self._contextMenu.addAction(self._tasks_list_controller.editTaskAction)
         self._contextMenu.addSeparator()
-        self._contextMenu.addAction(self._tasks_list_controller.deleteSelectedTasksAction)
         self._contextMenu.addAction(self._tasks_list_controller.completeSelectedTasksAction)
+        self._contextMenu.addAction(self._tasks_list_controller.deleteSelectedTasksAction)
         self._contextMenu.addSeparator()
-        self._contextMenu.addAction(self._tasks_list_controller.decreasePrioritySelectedTasksAction)
         self._contextMenu.addAction(self._tasks_list_controller.increasePrioritySelectedTasksAction)
+        self._contextMenu.addAction(self._tasks_list_controller.decreasePrioritySelectedTasksAction)
 
     def showContextMenu(self, position):
         tasks = self._tasks_list_controller._view.getSelectedTasks()

--- a/qtodotxt/ui/controllers/menu_controller.py
+++ b/qtodotxt/ui/controllers/menu_controller.py
@@ -38,11 +38,11 @@ class MenuController(QtCore.QObject):
         editMenu.addAction(tlc.createTaskAction)
         editMenu.addAction(tlc.editTaskAction)
         editMenu.addSeparator()
-        editMenu.addAction(tlc.deleteSelectedTasksAction)
         editMenu.addAction(tlc.completeSelectedTasksAction)
+        editMenu.addAction(tlc.deleteSelectedTasksAction)
         editMenu.addSeparator()
-        editMenu.addAction(tlc.decreasePrioritySelectedTasksAction)
         editMenu.addAction(tlc.increasePrioritySelectedTasksAction)
+        editMenu.addAction(tlc.decreasePrioritySelectedTasksAction)
 
     def _initHelpMenu(self):
         helpMenu = self._menu.addMenu('&Help')


### PR DESCRIPTION
I propose to switch the position of the following task related actions:
* delete / complete tasks
* decrease / increase priority

I think putting complete tasks before delete task and putting increase priority before decrease priority is more intuitive and with the new icon set #175 also visual more apealing.