### PR TITLE
Tell the user what to do if no PySide found

### DIFF
--- a/qtodotxt/app.py
+++ b/qtodotxt/app.py
@@ -5,6 +5,12 @@ import argparse
 import logging
 import sys
 
+try:
+    import PySide
+except ImportError:
+    print("Couldn't import PySide. Please make sure PySide is installed.")
+    sys.exit(1)
+
 from PySide import QtCore
 from PySide import QtGui
 


### PR DESCRIPTION
Print a nice error message instead of letting the user guess what's going wrong with the ugly default error message.