### PR TITLE
Update meta data for release 1.5

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,3 @@
 David Elentok
 Matthieu Nantern
-Mariano Draghi
+QTT Development Team

--- a/packaging/Debian/buildDebPackage.py
+++ b/packaging/Debian/buildDebPackage.py
@@ -16,7 +16,7 @@ from subprocess import call
 tmpDir="/tmp/"
 
 def dlTagFromGitHub(version):
-    remoteFile = urllib.request.urlopen('https://github.com/mNantern/QTodoTxt/archive/'+version+'.tar.gz')
+    remoteFile = urllib.request.urlopen('https://github.com/QTodoTxt/QTodoTxt/archive/'+version+'.tar.gz')
     contentDisposition=remoteFile.info()['Content-Disposition']
     fileName=contentDisposition.split('=')[1]
 

--- a/packaging/Debian/changelog
+++ b/packaging/Debian/changelog
@@ -1,3 +1,11 @@
+qtodotxt (1.5.0) unstable; urgency=low
+
+  * Publication of v1.5.0: see changelog here
+    https://github.com/QTodoTxt/QTodoTxt/wiki/Changelog#v150
+  * Initial release.
+
+ -- QTT Development Team <qtodotxt@googlegroups.com>  Sun, 21 Feb 2016 00:00:00 +0100
+
 qtodotxt (1.4.0) unstable; urgency=low
 
   * Publication of v1.4.0: see changelog here

--- a/packaging/Debian/control.tpl
+++ b/packaging/Debian/control.tpl
@@ -1,14 +1,14 @@
 Package: qtodotxt
 Version: $version
 Architecture: all
-Maintainer: Matthieu Nantern <matthieu.nantern@gmail.com>
+Maintainer: QTT Development Team
 Installed-Size: 3
 Depends: python3 (>=3.2), python3-pyside
 Section: utils
 Priority: optional
-Homepage: https://github.com/mNantern/QTodoTxt.git
+Homepage: https://github.com/QTodoTxt/QTodoTxt.git
 Description: cross-platform UI client for todo.txt files
  QTodoTxt is a cross-platform UI client for todo.txt files. It allows you to
  manage projects, contexts in a GTD way. You can use it on Linux, Windows, 
- Mac Os X. Your todo.txt file can be sync with Dropbox, Owncloud or what you 
+ Mac OS X. Your todo.txt file can be sync with Dropbox, Owncloud or what you 
  want, it's just a text file !

--- a/packaging/Debian/copyright
+++ b/packaging/Debian/copyright
@@ -1,10 +1,11 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: QTodoTxt
-Source: https://github.com/mNantern/QTodoTxt
+Source: https://github.com/QTodoTxt/QTodoTxt
 
 Files: *
 Copyright: Copyright 2011 David Elentok
-           Copyright 2013-2014 Matthieu Nantern 
+           Copyright 2013-2015 Matthieu Nantern
+           Copyright 2015-2016 QTT Development Team
 License: GPL-3+
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/packaging/MacOS/setup.py
+++ b/packaging/MacOS/setup.py
@@ -38,10 +38,10 @@ collect_packages('.', '', packages, excludes=['test'])
 # ======================================
 # Setup parameters
 setup(name='qtodotxt',
-      version='1.4.0',
-      author='Matthieu Nantern',
-      author_email='matthieu.nantern@gmail.com',
-      url='https://github.com/mNantern/QTodoTxt',
+      version='1.5.0',
+      author='QTT Development Team',
+      author_email='qtodotxt@googlegroups.com',
+      url='https://github.com/QTodoTxt/QTodoTxt',
       packages=packages,
       app=["qtodotxt/app.py"],
       setup_requires=["py2app"],

--- a/packaging/Windows/installer.iss
+++ b/packaging/Windows/installer.iss
@@ -2,9 +2,9 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "QTodoTxt"
-#define MyAppVersion "1.4.0"
-#define MyAppPublisher "Matthieu Nantern"
-#define MyAppURL "https://github.com/mNantern/QTodoTxt"
+#define MyAppVersion "1.5.0"
+#define MyAppPublisher "QTT Development Team"
+#define MyAppURL "https://github.com/QTodoTxt/QTodoTxt"
 #define MyAppExeName "qtodotxt.exe"
 
 [Setup]

--- a/packaging/Windows/setup.py
+++ b/packaging/Windows/setup.py
@@ -51,10 +51,10 @@ collect_resources(resources_root,css)
 # ======================================
 # Setup parameters
 setup(name='qtodotxt',
-      version='1.4.0',
-      author='Matthieu Nantern',
-      author_email='matthieu.nantern@gmail.com',
-      url='https://github.com/mNantern/QTodoTxt',
+      version='1.5.0',
+      author='QTT Development Team',
+      author_email='qtodotxt@googlegroups.com',
+      url='https://github.com/QTodoTxt/QTodoTxt',
       packages=packages,
       setup_requires=["py2exe"],
 

--- a/qtodotxt/ui/dialogs/about_dialog.py
+++ b/qtodotxt/ui/dialogs/about_dialog.py
@@ -1,13 +1,14 @@
 from PySide import QtGui
 
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 description = """<p>QTodoTxt is a cross-platform UI client for todo.txt files
  (see <a href="http://todotxt.com">http://todotxt.com</a>)</p>
 
-<p>Copyright &copy; David Elentok 2011</p>
-<p>Copyright &copy; Matthieu Nantern 2013</p>
+Copyright &copy; David Elentok 2011<br/>
+Copyright &copy; Matthieu Nantern 2013-2015<br/>
+Copyright &copy; QTT Development Team 2015-2016
 
 <h2>Links</h2>
 <ul>

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ import sys
 
 
 setup(name="qtodotxt", 
-      version="1.5alpha1",
+      version="1.5.0",
       description="Cross Platform todo.txt GUI",
-      author="many",
+      author="QTT Development Team",
       author_email="qtodotxt@googlegroups.com",
       url='https://github.com/QTodoTxt/QTodoTxt',
       packages=find_packages(include=("*.png")) + ["qtodotxt.ui.resources", "qtodotxt.ui.resources.css"],


### PR DESCRIPTION
I hope I've catched every place where something is to be changed. Please re-check it, I'm no expert for these things.

Who gets the emails written to "qtodotxt at googlegroups.com"? I would prefer removing all email adresses from the meta data, but I don't know whether this is allowed e.g. for setup.py.