### PR TITLE
fix crash of the program after minimizing

### DIFF
--- a/qtodotxt/ui/dialogs/settings.py
+++ b/qtodotxt/ui/dialogs/settings.py
@@ -94,6 +94,9 @@ class Settings(QtWidgets.QDialog):
     def setCloseToTray(self, val):
         self._save_int_cb("close_to_tray", val)
 
+    def closeEvent(self, event):
+        self.maincontroller.view.show()
+
 if __name__ == "__main__":
     QtCore.QCoreApplication.setOrganizationName("QTodoTxt")
     QtCore.QCoreApplication.setApplicationName("QTodoTxt")


### PR DESCRIPTION
After a sequence of actions:
1. to open the settings dialog
2. minimize to tray
3. to close the settings dialog

There is a drop in program (win 7 x64)

Made so that after closing the modal window reopened  parent window (before minimized)