### PR TITLE
Enter key on num lock pad now also opens a task which fixes #181.

### DIFF
--- a/qtodotxt/ui/controllers/tasks_list_controller.py
+++ b/qtodotxt/ui/controllers/tasks_list_controller.py
@@ -35,7 +35,7 @@ class TasksListController(QtCore.QObject):
 
     def _initEditTaskAction(self):
         action = QtWidgets.QAction(getIcon('TaskEdit.png'), '&Edit Task', self)
-        action.setShortcuts(['Ctrl+E'])
+        action.setShortcuts(['Ctrl+E', 'Enter'])
         action.triggered.connect(self.editTask)
         self.view.addListAction(action)
         self.editTaskAction = action


### PR DESCRIPTION
This should fix #181 - please merge.
I found an issue during this change for which I want to create a separate issue. When a task is selected and one selects the filter line and hit the num-lock-enter key the task would still open. I think this is not an intended behavior. (PLease give me feedback on that) I think this issue is not related to this change because if one selects a task and then selects the already selected filter on the left pane (so the right pane doesn't change - just loses its focus) and then presses the already implemented CTRL-E key makes the selected task on the right pane also open.
It seems to me that this was an issue befor I edit the code. Therefore I want to create an issue.

All 3 tests have been passed with my changes in this branch (obviously ;-) - it is such a small change)