### PR TITLE
Updates the Github Pages site

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,16 +18,16 @@
     <link rel="shortcut icon" href="favicon.png" />
   </head>
   <body>
-      <div id="header">
-        <nav>
-          <li class="fork"><a href="#downloads">Download</a></li>
-          <li class="downloads"><a href="https://github.com/mNantern/QTodoTxt">GitHub</a></li>
-          <li class="downloads"><a href="https://groups.google.com/d/forum/qtodotxt">Forum</a></li>
-          <li class="downloads"><a href="#documentation">Documentation</a></li>
-          <li class="downloads"><a href="#news">News</a></li>
-          <li class="downloads"><a href="#qtodotxt-">About</a></li>
-        </nav>
-      </div><!-- end header -->
+    <div id="header">
+      <nav>
+        <li class="fork"><a href="#downloads">Download</a></li>
+        <li class="downloads"><a href="https://github.com/QTodoTxt/QTodoTxt">GitHub</a></li>
+        <li class="downloads"><a href="https://groups.google.com/d/forum/qtodotxt">Forum</a></li>
+        <li class="downloads"><a href="#documentation">Documentation</a></li>
+        <li class="downloads"><a href="#news">News</a></li>
+        <li class="downloads"><a href="#qtodotxt-">About</a></li>
+      </nav>
+    </div><!-- end header -->
 
     <div class="wrapper">
 
@@ -35,85 +35,83 @@
         <div id="title">
           <h1>Qtodotxt</h1>
           <p>Cross Platform Todo manager</p>
-          <hr>
-          <span class="credits left">Project maintained by <a href="https://github.com/mNantern">Matthieu Nantern</a></span>
         </div>
 
         <h1>
-<a name="qtodotxt-" class="anchor" href="#qtodotxt-"><span class="octicon octicon-link"></span></a>QTodoTxt <a href="https://travis-ci.org/mNantern/QTodoTxt"><img src="https://travis-ci.org/mNantern/QTodoTxt.png?branch=master" alt="Build Status"></a>
-</h1>
+          <a name="qtodotxt-" class="anchor" href="#qtodotxt-"><span class="octicon octicon-link"></span></a>QTodoTxt <a href="https://travis-ci.org/QTodoTxt/QTodoTxt"><img src="https://travis-ci.org/QTodoTxt/QTodoTxt.png?branch=master" alt="Build Status"></a>
+        </h1>
 
-<p><br/>QTodoTxt is a cross-platform UI client for todo.txt files (see <a href="http://todotxt.com">todo.txt</a>).<br/><br/> It allows you to manage projects, contexts in a <a href="http://en.wikipedia.org/wiki/Getting_Things_Done">GTD</a> way.<br/> You can use it on Linux, Windows, Mac Os X and there are even IPhone and Android mobile App (<a href="http://todotxt.com/">right here</a>) !<br/><br/> Your todo.txt file can be sync with Dropbox, Owncloud or what you want, it's just a text file !</p>
+        <p><br/>QTodoTxt is a cross-platform UI client for todo.txt files (see <a href="http://todotxt.com">todo.txt</a>).<br/><br/> It allows you to manage projects, contexts in a <a href="http://en.wikipedia.org/wiki/Getting_Things_Done">GTD</a> way.<br/> You can use it on Linux, Windows, Mac Os X and there are even IPhone and Android mobile App (<a href="http://todotxt.com/">right here</a>) !<br/><br/> Your todo.txt file can be sync with Dropbox, Owncloud or what you want, it's just a text file !</p>
 
-<p><img src="https://github.com/mNantern/QTodoTxt/wiki/screenshots/QTodoTxt_main_view.png" alt="Main view"></p>
+        <p><img src="https://github.com/QTodoTxt/QTodoTxt/wiki/screenshots/QTodoTxt_main_view.png" alt="Main view"></p>
 
-<h2>
-<a name="news" class="anchor" href="#news"><span class="octicon octicon-link"></span></a>News</h2>
-<h3>22 Mar. 2014: Version 1.3.0 released!</h3>
-<p> I've just released v1.3.0 of QTodoTxt a cross-platform GUI for todo.txt.<br/>
-New features include better packaging (for Windows and Debian at least), a shortcut to change priority of selected tasks, a case insensitive search and <a href="https://github.com/mNantern/QTodoTxt/wiki/Changelog#v130">a lot more.</a><br/>
-You can download this latest version on <a href="#downloads">the project page.</a><br/>
-<br/>
-Feel free to try !<br/>
-I would also thank contributors to QTodoTxt: chaghi and dreuter.</p>
-<h3>12 Jan. 2014: Version 1.2.0 released!</h3>
-<p> I've just released v1.2.0 of QTodoTxt a cross-platform GUI for todo.txt.<br/>
-New features include support of FutureTasks, a Mac Os X package, a filter bar and <a href="https://github.com/mNantern/QTodoTxt/wiki/Changelog#v120">a lot more.</a><br/>
-You can download this latest version on <a href="#downloads">the project page.</a><br/>
-<br/>
-Feel free to try !<br/>
-I would also thank new contributors to QTodoTxt: chaghi, mgushee and CalumJEadie.</p>
-<h3>13 Aug. 2013: Version 1.1.0 released!</h3>
-<p> I've just released v1.1.0 of QTodoTxt.
-<br/>
-New features include an option to auto-archive done tasks, another one to enable auto-save of todo.txt <a href="https://github.com/mNantern/QTodoTxt/wiki/Changelog#v110"> and more.</a>
-<br/>
-You can download this version <a href="https://github.com/mNantern/QTodoTxt/wiki/Releases#v110">on my GitHub page</a> and some screenshots are available <a href="https://github.com/mNantern/QTodoTxt/wiki/Screenshots">here</a>.
-<br/>
-Feel free to try !</p>
-<h3>19 Jun. 2013: Version 1.0.0 released!</h3>
-<p>I've been searching for a cross-platform GUI for todo.txt for a while now but found nothing that match my criteria (utf8, due date, ...).
-<br/>
-So I've improved an initial work by David Elentok (thanks to him!) and I released v1.0.0 last week: <a href="https://github.com/mNantern/QTodoTxt/wiki/Releases#v100">download page</a>
-<br/>
-Feel free to try !</p>
+        <h2>
+          <a name="news" class="anchor" href="#news"><span class="octicon octicon-link"></span></a>News</h2>
+        <h3>22 Mar. 2014: Version 1.3.0 released!</h3>
+        <p> I've just released v1.3.0 of QTodoTxt a cross-platform GUI for todo.txt.<br/>
+        New features include better packaging (for Windows and Debian at least), a shortcut to change priority of selected tasks, a case insensitive search and <a href="https://github.com/QTodoTxt/QTodoTxt/wiki/Changelog#v130">a lot more.</a><br/>
+        You can download this latest version on <a href="#downloads">the project page.</a><br/>
+        <br/>
+        Feel free to try !<br/>
+        I would also thank contributors to QTodoTxt: chaghi and dreuter.</p>
+        <h3>12 Jan. 2014: Version 1.2.0 released!</h3>
+        <p> I've just released v1.2.0 of QTodoTxt a cross-platform GUI for todo.txt.<br/>
+        New features include support of FutureTasks, a Mac Os X package, a filter bar and <a href="https://github.com/QTodoTxt/QTodoTxt/wiki/Changelog#v120">a lot more.</a><br/>
+        You can download this latest version on <a href="#downloads">the project page.</a><br/>
+        <br/>
+        Feel free to try !<br/>
+        I would also thank new contributors to QTodoTxt: chaghi, mgushee and CalumJEadie.</p>
+        <h3>13 Aug. 2013: Version 1.1.0 released!</h3>
+        <p> I've just released v1.1.0 of QTodoTxt.
+        <br/>
+        New features include an option to auto-archive done tasks, another one to enable auto-save of todo.txt <a href="https://github.com/QTodoTxt/QTodoTxt/wiki/Changelog#v110"> and more.</a>
+        <br/>
+        You can download this version <a href="https://github.com/QTodoTxt/QTodoTxt/wiki/Releases#v110">on my GitHub page</a> and some screenshots are available <a href="https://github.com/QTodoTxt/QTodoTxt/wiki/Screenshots">here</a>.
+        <br/>
+        Feel free to try !</p>
+        <h3>19 Jun. 2013: Version 1.0.0 released!</h3>
+        <p>I've been searching for a cross-platform GUI for todo.txt for a while now but found nothing that match my criteria (utf8, due date, ...).
+        <br/>
+        So I've improved an initial work by David Elentok (thanks to him!) and I released v1.0.0 last week: <a href="https://github.com/QTodoTxt/QTodoTxt/wiki/Releases#v100">download page</a>
+        <br/>
+        Feel free to try !</p>
 
-<h2>
-<a name="downloads" class="anchor" href="#downloads"><span class="octicon octicon-link"></span></a>Downloads</h2>
+        <h2>
+          <a name="downloads" class="anchor" href="#downloads"><span class="octicon octicon-link"></span></a>Downloads</h2>
 
-<p>Latest stable release (v1.4.0):</p>
+        <p>Latest stable release (v1.4.0):</p>
 
-<ul>
-<li>For Ubuntu: <a href="http://dl.bintray.com/mnantern/deb/qtodotxt_1.4.0_all.deb">deb package</a>
-</li>
-<li>For Windows: <a href="http://dl.bintray.com/mnantern/generic/qtodotxt_1.4.0.exe">Windows installer</a>
-</li>
-<li>For Mac OS X: <a href="http://dl.bintray.com/mnantern/generic/QTodoTxt_1.4.0.dmg">Mac Os X installer</a>
-</li>
-<li>Linux: <a href="https://github.com/mNantern/QTodoTxt/archive/1.4.0.tar.gz">tar.gz archive</a>
-</li>
-</ul><p>For Debian/Ubuntu you can also add the following repo to your sources.list:</p>
+        <ul>
+          <li>For Ubuntu/Debian: <a href="https://github.com/QTodoTxt/QTodoTxt/releases/download/v1.6.1/qtodotxt_1.6.1_all_deb.zip">deb package</a>
+          </li>
+          <li>For Windows: <a href="https://github.com/QTodoTxt/QTodoTxt/releases/download/v1.6.1/qtodotxt_1.6.1.exe">Windows installer</a>
+          </li>
+          <li>For Mac OS X: <a href="http://dl.bintray.com/mnantern/generic/QTodoTxt_1.4.0.dmg">Mac Os X installer</a>
+          </li>
+          <li>Everywhere: <a href="https://github.com/QTodoTxt/QTodoTxt/archive/v1.6.1.tar.gz">tar.gz archive</a>
+          </li>
+        </ul><p>For Debian/Ubuntu you can also add the following repo to your sources.list:</p>
 
-<pre><code>echo "deb http://dl.bintray.com/mnantern/deb /" | sudo tee /etc/apt/sources.list.d/qtodotxt.list
-</code></pre>
+        <pre><code>echo "deb http://dl.bintray.com/mnantern/deb /" | sudo tee /etc/apt/sources.list.d/qtodotxt.list
+        </code></pre>
 
-<h2>
-<a name="documentation" class="anchor" href="#documentation"><span class="octicon octicon-link"></span></a>Documentation</h2>
+        <h2>
+          <a name="documentation" class="anchor" href="#documentation"><span class="octicon octicon-link"></span></a>Documentation</h2>
 
-<ul>
-<li><a href="https://github.com/mNantern/QTodoTxt/wiki/User-documentation">User documentation</a></li>
-<li>Stable and older releases: <a href="https://github.com/mNantern/QTodoTxt/wiki/Releases">Downloads</a>
-</li>
-<li><a href="https://github.com/mNantern/QTodoTxt/wiki/Changelog">Changelog</a></li>
-<li><a href="https://github.com/mNantern/QTodoTxt/issues">Defects and Enhancements</a></li>
-<li><a href="https://github.com/mNantern/QTodoTxt/wiki/Screenshots">Screenshots</a></li>
-</ul>
+        <ul>
+          <li><a href="https://github.com/QTodoTxt/QTodoTxt/wiki/User-documentation">User documentation</a></li>
+          <li>Stable and older releases: <a href="https://github.com/QTodoTxt/QTodoTxt/wiki/Releases">Downloads</a>
+          </li>
+          <li><a href="https://github.com/QTodoTxt/QTodoTxt/wiki/Changelog">Changelog</a></li>
+          <li><a href="https://github.com/QTodoTxt/QTodoTxt/issues">Defects and Enhancements</a></li>
+          <li><a href="https://github.com/QTodoTxt/QTodoTxt/wiki/Screenshots">Screenshots</a></li>
+        </ul>
 
-<p>Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/michigangraham">mattgraham</a></p>
+        <p>Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/michigangraham">mattgraham</a></p>
       </section>
 
     </div>
     <!--[if !IE]><script>fixScale(document);</script><![endif]-->
-    
+
   </body>
 </html>


### PR DESCRIPTION
I updated all the links to point to the new QTodoTxt project url.
They were broken before, since @mNantern removed the project.

I also removed the credit under the heading, since mNantern is no
longer actively maintaining the project.

Closes #300