### PR TITLE
Remaps the exit shortcut to `Ctrl+Q`

### DIFF
--- a/qtodotxt/ui/controllers/menu_controller.py
+++ b/qtodotxt/ui/controllers/menu_controller.py
@@ -91,7 +91,7 @@ class MenuController(QtCore.QObject):
 
     def _createExitAction(self):
         action = QtWidgets.QAction(getIcon('ApplicationExit.png'), 'E&xit', self)
-        action.setShortcuts(["Alt+F4"])
+        action.setShortcuts(["Ctrl+Q"])
         action.triggered.connect(self._main_controller.exit)
         return action
 


### PR DESCRIPTION
The original shortcut was `Alt+F4`, which is not typical
for most apps.

Closes #305