### PR TITLE
Implement priority based filter

### DIFF
--- a/qtodotxt/lib/file.py
+++ b/qtodotxt/lib/file.py
@@ -182,10 +182,12 @@ class File(object):
                          'Contexts': 0,
                          'Projects': 0,
                          'Complete': 0,
+                         'Priority': 0,
                          'DueCompl': 0,
                          'ProjCompl': 0,
                          'ContCompl': 0,
                          'UncatCompl': 0,
+                         'PrioCompl': 0,
                          'Due': 0})
         for task in self.tasks:
             nbProjects = len(task.projects)
@@ -200,6 +202,8 @@ class File(object):
                     counters['Uncategorized'] += 1
                 if task.due:
                     counters['Due'] += 1
+                if task.priority != "":
+                    counters['Priority'] += 1
             else:
                 counters['Complete'] += 1
                 if nbProjects > 0:
@@ -210,6 +214,8 @@ class File(object):
                     counters['UncatCompl'] += 1
                 if task.due:
                     counters['DueCompl'] += 1
+                if task.priority != "":
+                    counters['PrioCompl'] += 1
         return counters
 
 

--- a/qtodotxt/lib/filters.py
+++ b/qtodotxt/lib/filters.py
@@ -394,3 +394,18 @@ class FutureFilter(BaseFilter):
 
     def __str__(self):
         return "FutureFilter " % self.text
+
+class PriorityFilter(BaseFilter):
+    """
+    Task list filter that removes any completed tasks.
+
+    """
+    def __init__(self):
+        BaseFilter.__init__(self, 'Priority')
+
+    def isMatch(self, task):
+        return task.priority != ""
+
+    def __str__(self):
+        return "PriorityFilter " % self.text
+

--- a/qtodotxt/ui/controllers/filters_tree_controller.py
+++ b/qtodotxt/ui/controllers/filters_tree_controller.py
@@ -1,6 +1,6 @@
 from PyQt5 import QtCore
 from qtodotxt.lib.filters import ContextFilter, ProjectFilter, DueTodayFilter, DueTomorrowFilter, DueThisWeekFilter, \
-    DueThisMonthFilter, DueOverdueFilter
+    DueThisMonthFilter, DueOverdueFilter, PriorityFilter
 
 # class IFiltersTreeView(object):
 #    def addFilter(self, filter): pass

--- a/qtodotxt/ui/views/filters_tree_view.py
+++ b/qtodotxt/ui/views/filters_tree_view.py
@@ -2,7 +2,7 @@ from PyQt5 import QtCore, QtGui
 from PyQt5 import QtWidgets
 from qtodotxt.lib.filters import ContextFilter, CompleteTasksFilter, DueFilter, DueOverdueFilter, DueThisMonthFilter, \
     DueThisWeekFilter, DueTodayFilter, DueTomorrowFilter, HasContextsFilter, HasDueDateFilter, HasProjectsFilter, \
-    ProjectFilter, UncategorizedTasksFilter, AllTasksFilter
+    ProjectFilter, UncategorizedTasksFilter, AllTasksFilter, PriorityFilter
 
 
 class FiltersTreeView(QtWidgets.QWidget):
@@ -76,6 +76,8 @@ class FiltersTreeView(QtWidgets.QWidget):
         nbProjCompl = counters['ProjCompl']
         nbDueCompl = counters['DueCompl']
         nbUncatCompl = counters['UncatCompl']
+        nbPriority = counters['Priority']
+        nbPrioCompl = counters['PrioCompl']
 
         self._completeTasksItem.setText(0, "Complete (%d)" % nbComplete)
         if (show_completed is True):
@@ -83,12 +85,14 @@ class FiltersTreeView(QtWidgets.QWidget):
             self._dueItem.setText(0, "Due ({0}; {1})".format(nbDue, nbDueCompl))
             self._contextsItem.setText(0, "Contexts ({0}; {1})".format(nbContexts, nbContCompl))
             self._projectsItem.setText(0, "Projects ({0}; {1})".format(nbProjects, nbProjCompl))
+            self._priorityItem.setText(0, "Priority ({0}; {1})".format(nbPriority, nbPrioCompl))
             self._uncategorizedTasksItem.setText(0, "Uncategorized ({0}; {1})".format(nbUncategorized, nbUncatCompl))
         else:
             self._allTasksItem.setText(0, "All (%d)" % nbPending)
             self._contextsItem.setText(0, "Contexts (%d)" % nbContexts)
             self._projectsItem.setText(0, "Projects (%d)" % nbProjects)
             self._dueItem.setText(0, "Due (%d)" % nbDue)
+            self._priorityItem.setText(0, "Priority (%d)" % nbPriority)
             self._uncategorizedTasksItem.setText(0, "Uncategorized (%d)" % nbUncategorized)
 
     def selectAllTasksFilter(self):
@@ -109,6 +113,10 @@ class FiltersTreeView(QtWidgets.QWidget):
 
     def _selectDueRange(self, due):
         item = self._findItem(due, self._dueItem)
+        self._selectItem(item)
+
+    def _selectPriority(self, priority):
+        item = self._findItem(priority, self._priorityItem)
         self._selectItem(item)
 
     def _findItem(self, text, parentItem):
@@ -160,6 +168,10 @@ class FiltersTreeView(QtWidgets.QWidget):
                                                   ['Projects'],
                                                   HasProjectsFilter(),
                                                   QtGui.QIcon(self.style + '/resources/FilterProjects.png'))
+        self._priorityItem = FilterTreeWidgetItem(None,
+                                                       ['Priorities'],
+                                                       PriorityFilter(),
+                                                       QtGui.QIcon(self.style + '/resources/FilterComplete.png'))
         self._completeTasksItem = FilterTreeWidgetItem(None,
                                                        ['Complete'],
                                                        CompleteTasksFilter(),
@@ -170,6 +182,7 @@ class FiltersTreeView(QtWidgets.QWidget):
             self._dueItem,
             self._contextsItem,
             self._projectsItem,
+            self._priorityItem,
             self._completeTasksItem
         ])
 
@@ -193,6 +206,7 @@ class FiltersTreeView(QtWidgets.QWidget):
         self._treeItemByFilterType[HasProjectsFilter] = self._projectsItem
         self._treeItemByFilterType[HasDueDateFilter] = self._dueItem
         self._treeItemByFilterType[HasContextsFilter] = self._contextsItem
+        self._treeItemByFilterType[PriorityFilter] = self._priorityItem
 
     def _tree_itemSelectionChanged(self):
         self.filterSelectionChanged.emit(self.getSelectedFilters())
@@ -214,6 +228,8 @@ class FiltersTreeView(QtWidgets.QWidget):
             self._selectDueRange(filter.text)
         elif isinstance(filter, DueOverdueFilter):
             self._selectDueRange(filter.text)
+        elif isinstance(filter, PriorityFilter):
+            self._selectPriority(filter.text)
         else:
             item = self._treeItemByFilterType[type(filter)]
             self._selectItem(item)


### PR DESCRIPTION
First pass to implement a priority based filter - #375 
===
This filter allows users to only see tasks which were assigned a priority.

I currently use the "FilterComplete.png" icon for testing purpose.

I had to touch code in a surprisingly high amount of places to do this. 
I followed existing code conventions but i think a refactoring could be interesting to remove some redundancy when adding filters.

Next steps : 
I think it can also be useful to be able to see only tasks with certain priority (Like only A priority tasks). 
This could be implemented similarly to project and context filters and i will work on it later.