### PR TITLE
Repair recurring tasks

### DIFF
--- a/qtodotxt/ui/controllers/tasks_list_controller.py
+++ b/qtodotxt/ui/controllers/tasks_list_controller.py
@@ -201,7 +201,8 @@ class TasksListController(QtCore.QObject):
         # Set new due date in old task text
         rec_text = task.updateDateInTask(task.text, next_due_date)
         # create a new task duplicate
-        return self.createTask(rec_text)
+        self._createTask(rec_text)
+        return
 
     def _incrWorkDays(self, startDate, daysToIncrement):
         while daysToIncrement > 0:


### PR DESCRIPTION
Should fix #408. Initial try. Works for me with a simple recurring task: `2016-12-08 Feed Schrodinger's Cat rec:+1d due:2014-02-23`
No dynamic or static analysis done.
@sttrebo