### PR TITLE
fix TypeError recognized by python 3.10

### DIFF
--- a/qtodotxt/ui/views/tasks_search_view.py
+++ b/qtodotxt/ui/views/tasks_search_view.py
@@ -39,8 +39,9 @@ class TasksSearchView(QtWidgets.QLineEdit):
         sz = self.clearButton.sizeHint()
         frameWidth = self.style().pixelMetric(QtWidgets.QStyle.PM_DefaultFrameWidth)
         self.clearButton.move(self.rect().right() - frameWidth - sz.width(),
-                              (self.rect().bottom() + 1 - sz.height()) / 2)
-        self.searchButton.move(self.rect().left() + 1, (self.rect().bottom() + 1 - sz.height()) / 2)
+                              int((self.rect().bottom() + 1 - sz.height()) / 2))
+        self.searchButton.move(self.rect().left() + 1,
+                               int((self.rect().bottom() + 1 - sz.height()) / 2))
 
     def getSearchText(self):
         return self._searchText


### PR DESCRIPTION
the TypeError prevents QTodotxt from starting after update to
python 3.10.
after Upgrading to Python 3.10, qtodotxt does not start...